### PR TITLE
allowing optional attribute iccid for query device info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-reactor (0.0.37)
+    conduit-reactor (0.0.39)
       conduit (~> 0.6.0)
       multi_json (~> 1.10.1)
 

--- a/lib/conduit/reactor/actions/query_device_info.rb
+++ b/lib/conduit/reactor/actions/query_device_info.rb
@@ -4,6 +4,7 @@ module Conduit::Driver::Reactor
   class QueryDeviceInfo < Conduit::Driver::Reactor::Base
     url_route           '/carriers'
     required_attributes :carrier_id, :device_serial_number
+    optional_attributes :iccid
     http_method         :post
 
     def remote_url

--- a/lib/conduit/reactor/version.rb
+++ b/lib/conduit/reactor/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Reactor
-    VERSION = '0.0.38'
+    VERSION = '0.0.39'
   end
 end

--- a/spec/conduit/reactor/actions/query_device_info_spec.rb
+++ b/spec/conduit/reactor/actions/query_device_info_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe QueryDeviceInfo do
 
   let(:query_device_attributes) do
-    credentials.merge(carrier_id: 1, device_serial_number: '111222333444555667', mock_status: :success)
+    credentials.merge(carrier_id: 1, device_serial_number: '111222333444555667',
+                      iccid: '89011200000403604860', mock_status: :success)
   end
 
   let(:query_device) do


### PR DESCRIPTION
```
Finished in 0.40168 seconds (files took 0.22773 seconds to load)
269 examples, 0 failures
```