### PR TITLE
adding optional service_type to query_usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-reactor (1.2.3)
+    conduit-reactor (1.2.4)
       conduit (~> 0.6.0)
       multi_json (~> 1.10.1)
       pry-rails (~> 0.3.2)

--- a/lib/conduit/reactor/actions/query_usage.rb
+++ b/lib/conduit/reactor/actions/query_usage.rb
@@ -4,6 +4,7 @@ module Conduit::Driver::Reactor
   class QueryUsage < Conduit::Driver::Reactor::Base
     url_route           '/usages'
     required_attributes :mdn, :starting_at, :ending_at
+    optional_attributes :service_type
     http_method         :get
   end
 end

--- a/lib/conduit/reactor/decorators/query_usage.rb
+++ b/lib/conduit/reactor/decorators/query_usage.rb
@@ -4,9 +4,10 @@ module Conduit::Reactor::Decorators
   class QueryUsageDecorator < Base
     def query_usage_attributes
       {}.tap do |h|
-        h[:mdn]         = mdn         if mdn
-        h[:starting_at] = starting_at if starting_at
-        h[:ending_at]   = ending_at   if ending_at
+        h[:mdn]          = mdn          if mdn
+        h[:starting_at]  = starting_at  if starting_at
+        h[:ending_at]    = ending_at    if ending_at
+        h[:service_type] = service_type if service_type
       end
     end
   end

--- a/lib/conduit/reactor/version.rb
+++ b/lib/conduit/reactor/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Reactor
-    VERSION = '1.2.3'
+    VERSION = '1.2.4'
   end
 end

--- a/spec/conduit/reactor/actions/query_usage_spec.rb
+++ b/spec/conduit/reactor/actions/query_usage_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe QueryUsage do
   let(:options) do
     credentials.merge(mdn: '5612223811', starting_at: Time.mktime(2015, 4, 1),
-      ending_at: Time.mktime(2015, 5, 1))
+      ending_at: Time.mktime(2015, 5, 1), service_type: 'voice')
   end
 
   it_should_behave_like 'parser success response' do


### PR DESCRIPTION
This adds an optional parameter, `service_type` that allows us to filter usage records by 'voice', 'text', or 'data'