### PR TITLE
allow queries by service period

### DIFF
--- a/lib/conduit/reactor/actions/query_usage.rb
+++ b/lib/conduit/reactor/actions/query_usage.rb
@@ -3,8 +3,16 @@ require 'conduit/reactor/actions/base'
 module Conduit::Driver::Reactor
   class QueryUsage < Conduit::Driver::Reactor::Base
     url_route           '/usages'
-    required_attributes :mdn, :starting_at, :ending_at
-    optional_attributes :service_type
+    required_attributes :mdn
+    optional_attributes :starting_at, :ending_at, :service_period_uuid, :service_type
     http_method         :get
+
+
+    def initialize(options = {})
+      super
+      unless (@options[:starting_at] && @options[:ending_at]) || @options[:service_period_uuid]
+        raise ArgumentError, "You need to supply either a service_period_uuid, or starting_at and ending_at"
+      end
+    end
   end
 end

--- a/lib/conduit/reactor/decorators/query_usage.rb
+++ b/lib/conduit/reactor/decorators/query_usage.rb
@@ -4,10 +4,11 @@ module Conduit::Reactor::Decorators
   class QueryUsageDecorator < Base
     def query_usage_attributes
       {}.tap do |h|
-        h[:mdn]          = mdn          if mdn
-        h[:starting_at]  = starting_at  if starting_at
-        h[:ending_at]    = ending_at    if ending_at
-        h[:service_type] = service_type if service_type
+        h[:mdn]                 = mdn          if mdn
+        h[:starting_at]         = starting_at  if starting_at
+        h[:ending_at]           = ending_at    if ending_at
+        h[:service_type]        = service_type if service_type
+        h[:service_period_uuid] = service_period_uuid if service_period_uuid
       end
     end
   end

--- a/lib/conduit/reactor/version.rb
+++ b/lib/conduit/reactor/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Reactor
-    VERSION = '1.3.0'
+    VERSION = '1.3.1'
   end
 end


### PR DESCRIPTION
This is the corresponding PR for https://github.com/Hello-Labs/reactor_api/pull/644 to make it so we can get usage info by service period, which is more accurate, and less ugly than by time.