### PR TITLE
enhance error vs failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-reactor (1.3.0)
+    conduit-reactor (1.3.2)
       conduit (~> 0.6.0)
       multi_json (~> 1.10.1)
       pry-rails (~> 0.3.2)

--- a/lib/conduit/reactor/parsers/base.rb
+++ b/lib/conduit/reactor/parsers/base.rb
@@ -27,8 +27,6 @@ module Conduit::Driver::Reactor
 
         if @success
           in_progress? ? result : 'success'
-        elsif internal_server_error? || !response_content?
-          'error'
         else
           'failure'
         end
@@ -49,7 +47,7 @@ module Conduit::Driver::Reactor
 
       def failure
         failure_msg = { 'errors' => { 'base' => ['Request failed.'] } }
-        return failure_msg if object_path('result') == 'failure'
+        return failure_msg if object_path('result') == 'failure' || !response_content?
       end
 
       private

--- a/lib/conduit/reactor/parsers/bucket_attributes.rb
+++ b/lib/conduit/reactor/parsers/bucket_attributes.rb
@@ -50,7 +50,7 @@ module Conduit::Driver::Reactor
     end
 
     def response_content?
-      object_path('buckets').nil?
+      !object_path('buckets').nil?
     end
 
   end

--- a/lib/conduit/reactor/parsers/query_service_details.rb
+++ b/lib/conduit/reactor/parsers/query_service_details.rb
@@ -43,7 +43,7 @@ module Conduit::Driver::Reactor
     end
 
     def response_content?
-      object_path('usage_summary').nil?
+      !object_path('usage_summary').nil?
     end
   end
 end

--- a/lib/conduit/reactor/parsers/query_subscription.rb
+++ b/lib/conduit/reactor/parsers/query_subscription.rb
@@ -7,7 +7,7 @@ module Conduit::Driver::Reactor
     end
 
     def response_content?
-      object_path('carrier_data').nil?
+      !object_path('carrier_data').nil?
     end
   end
 end

--- a/lib/conduit/reactor/version.rb
+++ b/lib/conduit/reactor/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module Reactor
-    VERSION = '1.3.1'
+    VERSION = '1.3.2'
   end
 end

--- a/spec/support/shared_parser_examples.rb
+++ b/spec/support/shared_parser_examples.rb
@@ -24,7 +24,7 @@ shared_examples_for 'parser error response' do
     should eql expected
   end
   it                    { should be_an_instance_of parser }
-  its(:response_status) { should eql 'error' }
+  its(:response_status) { should eql 'failure' }
   its(:response_errors) { should_not be_empty }
 end
 


### PR DESCRIPTION
At the moment conduit-sprint is returning success or failure, conduit-reactor is returning success failure and error. Ive consolidated this to just success and failure for now. Conduit-sprint response_status - https://github.com/conduit/conduit-sprint/blob/master/lib/conduit/sprint/parsers/base.rb#L39

Also this change revealed some bugs in the action parsers that has been fixed.